### PR TITLE
Semantic improvement for IndicatorOverIndicatorStrategy

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -55,13 +55,13 @@ public class CCICorrectionStrategy {
         ConstantIndicator<Double> minus100 = new ConstantIndicator<Double>(-100d);
 
         // Trend
-        IndicatorOverIndicatorStrategy bullTrend = new IndicatorOverIndicatorStrategy(plus100, longCci);
-        IndicatorOverIndicatorStrategy bearTrend = new IndicatorOverIndicatorStrategy(minus100, longCci);
+        IndicatorOverIndicatorStrategy bullTrend = new IndicatorOverIndicatorStrategy(longCci, plus100);
+        IndicatorOverIndicatorStrategy bearTrend = new IndicatorOverIndicatorStrategy(longCci, minus100);
         Strategy trend = new CombinedBuyAndSellStrategy(bullTrend, bearTrend);
 
         // Signals
-        IndicatorOverIndicatorStrategy buySignal = new IndicatorOverIndicatorStrategy(shortCci, minus100);
-        IndicatorOverIndicatorStrategy sellSignal = new IndicatorOverIndicatorStrategy(shortCci, plus100);
+        IndicatorOverIndicatorStrategy buySignal = new IndicatorOverIndicatorStrategy(minus100, shortCci);
+        IndicatorOverIndicatorStrategy sellSignal = new IndicatorOverIndicatorStrategy(plus100, shortCci);
         Strategy signals = new CombinedBuyAndSellStrategy(buySignal, sellSignal);
 
         return trend.and(signals);

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -64,10 +64,10 @@ public class GlobalExtremaStrategy {
         LowestValueIndicator weekMinPrice = new LowestValueIndicator(minPrices, NB_TICKS_PER_WEEK);
 
         // Going long if the close price goes below the min price
-        IndicatorOverIndicatorStrategy buySignal = new IndicatorOverIndicatorStrategy(closePrices, new SimpleMultiplierIndicator(weekMinPrice, 1.004));
+        IndicatorOverIndicatorStrategy buySignal = new IndicatorOverIndicatorStrategy(new SimpleMultiplierIndicator(weekMinPrice, 1.004), closePrices);
 
         // Going short if the close price goes above the max price
-        IndicatorOverIndicatorStrategy sellSignal = new IndicatorOverIndicatorStrategy(new SimpleMultiplierIndicator(weekMaxPrice, 0.996), closePrices);
+        IndicatorOverIndicatorStrategy sellSignal = new IndicatorOverIndicatorStrategy(closePrices, new SimpleMultiplierIndicator(weekMaxPrice, 0.996));
 
         Strategy signals = new CombinedBuyAndSellStrategy(buySignal, sellSignal);
 

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -61,7 +61,7 @@ public class MovingMomentumStrategy {
 
         // The bias is bullish when the shorter-moving average moves above the longer moving average.
         // The bias is bearish when the shorter-moving average moves below the longer moving average.
-        IndicatorOverIndicatorStrategy shortEmaAboveLongEma = new IndicatorOverIndicatorStrategy(longEma, shortEma);
+        IndicatorOverIndicatorStrategy shortEmaAboveLongEma = new IndicatorOverIndicatorStrategy(shortEma, longEma);
 
         StochasticOscillatorKIndicator stochasticOscillK = new StochasticOscillatorKIndicator(series, 14);
         StochasticOscillatorDIndicator stochasticOscillD = new StochasticOscillatorDIndicator(stochasticOscillK);
@@ -72,7 +72,7 @@ public class MovingMomentumStrategy {
         MACDIndicator macd = new MACDIndicator(closePrice, 9, 26);
         EMAIndicator emaMacd = new EMAIndicator(macd, 18);
 
-        IndicatorOverIndicatorStrategy macdAboveSignalLine = new IndicatorOverIndicatorStrategy(emaMacd, macd);
+        IndicatorOverIndicatorStrategy macdAboveSignalLine = new IndicatorOverIndicatorStrategy(macd, emaMacd);
 
         return shortEmaAboveLongEma
                 .and(new CombinedBuyAndSellStrategy(support20, resist80))

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -58,11 +58,11 @@ public class RSI2Strategy {
 
         // Exit point.
         // Exiting long positions on a move above the 5-period SMA and short positions on a move below the 5-day SMA.
-        IndicatorOverIndicatorStrategy priceBelowSma = new IndicatorOverIndicatorStrategy(closePrice, shortSma);
+        IndicatorOverIndicatorStrategy priceBelowSma = new IndicatorOverIndicatorStrategy(shortSma, closePrice);
 
         // Identifying the major trend using a long-term moving average.
         // The long-term trend is up when a security is above its 200-period SMA and down when a security is below its 200-period SMA.
-        IndicatorOverIndicatorStrategy shortSmaAboveLongSma = new IndicatorOverIndicatorStrategy(longSma, shortSma);
+        IndicatorOverIndicatorStrategy shortSmaAboveLongSma = new IndicatorOverIndicatorStrategy(shortSma, longSma);
 
         // Identifying buying or selling opportunities within the bigger trend.
         // We use a 2-period RSI indicator.

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/strategies/IndicatorOverIndicatorStrategy.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/strategies/IndicatorOverIndicatorStrategy.java
@@ -27,8 +27,8 @@ import eu.verdelhan.ta4j.Indicator;
 /**
  * Indicator over indicator strategy.
  * <p>
- * Enter: when the value of the first {@link Indicator indicator} is strictly less than the value of the second one<br>
- * Exit: when the value of the first {@link Indicator indicator} is strictly greater than the value of the second one
+ * Enter: when the value of the first {@link Indicator indicator} is strictly greater than the value of the second one<br>
+ * Exit: when the value of the first {@link Indicator indicator} is strictly lesser than the value of the second one
  */
 public class IndicatorOverIndicatorStrategy extends AbstractStrategy {
     
@@ -49,16 +49,16 @@ public class IndicatorOverIndicatorStrategy extends AbstractStrategy {
 
     @Override
     public boolean shouldEnter(int index) {
-        return (first.getValue(index) < second.getValue(index));
-    }
-
-    @Override
-    public boolean shouldExit(int index) {
         return (first.getValue(index) > second.getValue(index));
     }
 
     @Override
+    public boolean shouldExit(int index) {
+        return (first.getValue(index) < second.getValue(index));
+    }
+
+    @Override
     public String toString() {
-        return String.format("%s upper: %s lower: %s", this.getClass().getSimpleName(), first, second);
+        return String.format("%s : %s over %s", this.getClass().getSimpleName(), first, second);
     }
 }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/strategies/IndicatorOverIndicatorStrategyTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/strategies/IndicatorOverIndicatorStrategyTest.java
@@ -41,9 +41,9 @@ public class IndicatorOverIndicatorStrategyTest {
     @Before
     public void setUp() {
 
-        first = new MockIndicator<Double>(new Double[] {4d, 7d, 9d, 6d, 3d, 2d});
-        second = new MockIndicator<Double>(new Double[] {3d, 6d, 10d, 8d, 2d, 1d});
 
+        first = new MockIndicator<Double>(new Double[] {3d, 6d, 10d, 8d, 2d, 1d});
+        second = new MockIndicator<Double>(new Double[] {4d, 7d, 9d, 6d, 3d, 2d});
     }
 
     @Test

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/strategies/ParabolicSarAndDMIStrategyTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/strategies/ParabolicSarAndDMIStrategyTest.java
@@ -51,9 +51,9 @@ public class ParabolicSarAndDMIStrategyTest {
     {
         TimeSeries series1 = new MockTimeSeries(6, 11, 6, 5, 9);
         TimeSeries series2 = new MockTimeSeries(10, 9, 7, 6, 6);
-        
-        TimeSeries series3 = new MockTimeSeries(1, 1, 1, 1, 1);
-        TimeSeries series4 = new MockTimeSeries(2, 2, 2, 2, 0);
+
+        TimeSeries series3 = new MockTimeSeries(2, 2, 2, 2, 0);
+        TimeSeries series4 = new MockTimeSeries(1, 1, 1, 1, 1);
         
         IndicatorCrossedIndicatorStrategy indicatorCrossedIndicator = new IndicatorCrossedIndicatorStrategy(new ClosePriceIndicator(series1), new ClosePriceIndicator(series2));
         IndicatorOverIndicatorStrategy indicatorOverIndicator = new IndicatorOverIndicatorStrategy(new ClosePriceIndicator(series3), new ClosePriceIndicator(series4));


### PR DESCRIPTION
Reversed order for indicators in IndicatorOverIndicatorStrategy to avoid confusion on what this strategy does. The strategy will now enter when the first indicator is over the second indicator, rather than the other way around.

I guess what remains is to update the code examples in the wiki.
