### PR TITLE
Fixed StandardDeviationIndicator formula

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/StandardDeviationIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/StandardDeviationIndicator.java
@@ -59,6 +59,7 @@ public class StandardDeviationIndicator extends CachedIndicator<TADecimal> {
             TADecimal pow = indicator.getValue(i).minus(average).pow(2);
             standardDeviation = standardDeviation.plus(pow);
         }
+        standardDeviation = standardDeviation.dividedBy(new TADecimal(index + 1));
         return standardDeviation.sqrt();
     }
 


### PR DESCRIPTION
The formula for standard deviation of a population needs the sum to be divided by the number of elements before the square root. I added the line to get the proper formula.
