### PR TITLE
Update TimeSeries.run() (fix for #39)

### DIFF
--- a/5jhqgytq.etv.txt
+++ b/5jhqgytq.etv.txt
@@ -1,0 +1,66 @@
+﻿ Merge branch 'master' of https://github.com/mdeverdelhan/ta4j
+
+Conflicts:
+	ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#
+# It looks like you may be committing a merge.
+# If this is not correct, please remove the file
+#	.git/MERGE_HEAD
+# and try again.
+
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch master
+# Your branch is up-to-date with 'origin/master'.
+#
+# All conflicts fixed but you are still merging.
+#
+# Changes to be committed:
+#	modified:   README.md
+#	modified:   pom.xml
+#	modified:   ta4j-examples/pom.xml
+#	modified:   ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+#	modified:   ta4j/pom.xml
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Decimal.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Indicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Rule.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Strategy.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Trade.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/CashFlow.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/criteria/MaximumDrawdownCriterion.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/criteria/VersusBuyAndHoldCriterion.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/CloseLocationValueIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/simple/VolumeIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ZLEMAIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/AccumulationDistributionIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/ChaikinMoneyFlowIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/NVIIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/PVIIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/trading/rules/AbstractRule.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/CloseLocationValueIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/simple/VolumeIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/EMAIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/ZLEMAIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/AccumulationDistributionIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/NVIIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/OnBalanceVolumeIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/PVIIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/mocks/MockTick.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/StopGainRuleTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/StopLossRuleTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/WaitForRuleTest.java
+#
+# Changes not staged for commit:
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#
+# Untracked files:
+#	gonqugfx.idc.txt
+#
+

--- a/gonqugfx.idc.txt
+++ b/gonqugfx.idc.txt
@@ -1,0 +1,63 @@
+﻿Merge branch 'master' of https://github.com/mdeverdelhan/ta4j
+
+Conflicts:
+	ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#
+# It looks like you may be committing a merge.
+# If this is not correct, please remove the file
+#	.git/MERGE_HEAD
+# and try again.
+
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch master
+# Your branch is up-to-date with 'origin/master'.
+#
+# All conflicts fixed but you are still merging.
+#
+# Changes to be committed:
+#	modified:   README.md
+#	modified:   pom.xml
+#	modified:   ta4j-examples/pom.xml
+#	modified:   ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+#	modified:   ta4j/pom.xml
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Decimal.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Indicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Rule.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Strategy.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Trade.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/CashFlow.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/criteria/MaximumDrawdownCriterion.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/analysis/criteria/VersusBuyAndHoldCriterion.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/CloseLocationValueIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/simple/VolumeIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ZLEMAIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/AccumulationDistributionIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/ChaikinMoneyFlowIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/NVIIndicator.java
+#	new file:   ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volume/PVIIndicator.java
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/trading/rules/AbstractRule.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/CloseLocationValueIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/simple/VolumeIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/EMAIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/ZLEMAIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/AccumulationDistributionIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/NVIIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/OnBalanceVolumeIndicatorTest.java
+#	new file:   ta4j/src/test/java/eu/verdelhan/ta4j/indicators/volume/PVIIndicatorTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/mocks/MockTick.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/StopGainRuleTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/StopLossRuleTest.java
+#	modified:   ta4j/src/test/java/eu/verdelhan/ta4j/trading/rules/WaitForRuleTest.java
+#
+# Changes not staged for commit:
+#	modified:   ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+#
+

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
@@ -74,9 +74,8 @@ public class Tick {
      * @param closePrice the close price of the tick period
      * @param volume the volume of the tick period
      */
-    public Tick(DateTime endTime, Period timePeriod, double openPrice, double highPrice, double lowPrice, double closePrice, double volume) {
-        this(endTime, timePeriod,
-                Decimal.valueOf(openPrice),
+    public Tick(DateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume) {
+        this(endTime, Decimal.valueOf(openPrice),
                 Decimal.valueOf(highPrice),
                 Decimal.valueOf(lowPrice),
                 Decimal.valueOf(closePrice),

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
@@ -79,8 +79,9 @@ public class Tick {
      * @param closePrice the close price of the tick period
      * @param volume the volume of the tick period
      */
-    public Tick(DateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume) {
-        this(endTime, Decimal.valueOf(openPrice),
+    public Tick(DateTime endTime, Period timePeriod, double openPrice, double highPrice, double lowPrice, double closePrice, double volume) {
+        this(endTime, timePeriod,
+                Decimal.valueOf(openPrice),
                 Decimal.valueOf(highPrice),
                 Decimal.valueOf(lowPrice),
                 Decimal.valueOf(closePrice),
@@ -96,8 +97,8 @@ public class Tick {
      * @param closePrice the close price of the tick period
      * @param volume the volume of the tick period
      */
-    public Tick(DateTime endTime, Decimal openPrice, Decimal highPrice, Decimal lowPrice, Decimal closePrice, Decimal volume) {
-        this.timePeriod = Period.days(1);
+    public Tick(DateTime endTime, Period timePeriod, Decimal openPrice, Decimal highPrice, Decimal lowPrice, Decimal closePrice, Decimal volume) {
+        this.timePeriod = timePeriod;
         this.endTime = endTime;
         this.beginTime = endTime.minus(timePeriod);
         this.openPrice = openPrice;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
@@ -3,23 +3,22 @@
  *
  * Copyright (c) 2014-2015 Marc de Verdelhan & respective authors (see AUTHORS)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package eu.verdelhan.ta4j;
 
@@ -33,8 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Sequence of {@link Tick ticks} separated by a predefined period (e.g. 15
- * minutes, 1 day, etc.)
+ * Sequence of {@link Tick ticks} separated by a predefined period (e.g. 15 minutes, 1 day, etc.)
  * <p>
  * Notably, a {@link TimeSeries time series} can be:
  * <ul>
@@ -46,46 +44,27 @@ import org.slf4j.LoggerFactory;
  */
 public class TimeSeries {
 
-    /**
-     * The logger
-     */
+    /** The logger */
     private final Logger log = LoggerFactory.getLogger(getClass());
-    /**
-     * Name of the series
-     */
+    /** Name of the series */
     private final String name;
-    /**
-     * Begin index of the time series
-     */
+    /** Begin index of the time series */
     private int beginIndex = -1;
-    /**
-     * End index of the time series
-     */
+    /** End index of the time series */
     private int endIndex = -1;
-    /**
-     * List of ticks
-     */
+    /** List of ticks */
     private final List<Tick> ticks;
-    /**
-     * Time period of the series
-     */
+    /** Time period of the series */
     private Period timePeriod;
-    /**
-     * Maximum number of ticks for the time series
-     */
+    /** Maximum number of ticks for the time series */
     private int maximumTickCount = Integer.MAX_VALUE;
-    /**
-     * Number of removed ticks
-     */
+    /** Number of removed ticks */
     private int removedTicksCount = 0;
-    /**
-     * True if the current series is a sub-series, false otherwise
-     */
+    /** True if the current series is a sub-series, false otherwise */
     private boolean subSeries = false;
 
     /**
      * Constructor.
-     *
      * @param name the name of the series
      * @param ticks the list of ticks of the series
      */
@@ -95,7 +74,6 @@ public class TimeSeries {
 
     /**
      * Constructor of an unnamed series.
-     *
      * @param ticks the list of ticks of the series
      */
     public TimeSeries(List<Tick> ticks) {
@@ -104,7 +82,6 @@ public class TimeSeries {
 
     /**
      * Constructor.
-     *
      * @param name the name of the series
      * @param timePeriod the time period (between 2 ticks)
      */
@@ -128,13 +105,11 @@ public class TimeSeries {
 
     /**
      * Constructor.
-     *
      * @param name the name of the series
      * @param ticks the list of ticks of the series
      * @param beginIndex the begin index (inclusive) of the time series
      * @param endIndex the end index (inclusive) of the time series
-     * @param subSeries true if the current series is a sub-series, false
-     * otherwise
+     * @param subSeries true if the current series is a sub-series, false otherwise
      */
     private TimeSeries(String name, List<Tick> ticks, int beginIndex, int endIndex, boolean subSeries) {
         // TODO: add null checks and out of bounds checks
@@ -219,8 +194,7 @@ public class TimeSeries {
     }
 
     /**
-     * @return the description of the series period (e.g. "from 12:00 21/01/2014
-     * to 12:15 21/01/2014")
+     * @return the description of the series period (e.g. "from 12:00 21/01/2014 to 12:15 21/01/2014")
      */
     public String getSeriesPeriodDescription() {
         StringBuilder sb = new StringBuilder();
@@ -245,11 +219,8 @@ public class TimeSeries {
     /**
      * Sets the maximum number of ticks that will be retained in the series.
      * <p>
-     * If a new tick is added to the series such that the number of ticks will
-     * exceed the maximum tick count, then the FIRST tick in the series is
-     * automatically removed, ensuring that the maximum tick count is not
-     * exceeded.
-     *
+     * If a new tick is added to the series such that the number of ticks will exceed the maximum tick count,
+     * then the FIRST tick in the series is automatically removed, ensuring that the maximum tick count is not exceeded.
      * @param maximumTickCount the maximum tick count
      */
     public void setMaximumTickCount(int maximumTickCount) {
@@ -281,10 +252,8 @@ public class TimeSeries {
      * Adds a tick at the end of the series.
      * <p>
      * Begin index set to 0 if if wasn't initialized.<br>
-     * End index set to 0 if if wasn't initialized, or incremented if it matches
-     * the end of the series.<br>
+     * End index set to 0 if if wasn't initialized, or incremented if it matches the end of the series.<br>
      * Exceeding ticks are removed.
-     *
      * @param tick the tick to be added
      * @see TimeSeries#setMaximumTickCount(int)
      */
@@ -310,18 +279,13 @@ public class TimeSeries {
     }
 
     /**
-     * Returns a new time series which is a view of a subset of the current
-     * series.
+     * Returns a new time series which is a view of a subset of the current series.
      * <p>
-     * The new series has begin and end indexes which correspond to the bounds
-     * of the sub-set into the full series.<br>
-     * The tick of the series are shared between the original time series and
-     * the returned one (i.e. no copy).
-     *
+     * The new series has begin and end indexes which correspond to the bounds of the sub-set into the full series.<br>
+     * The tick of the series are shared between the original time series and the returned one (i.e. no copy).
      * @param beginIndex the begin index (inclusive) of the time series
      * @param endIndex the end index (inclusive) of the time series
-     * @return a constrained {@link TimeSeries time series} which is a sub-set
-     * of the current series
+     * @return a constrained {@link TimeSeries time series} which is a sub-set of the current series
      */
     public TimeSeries subseries(int beginIndex, int endIndex) {
         if (maximumTickCount != Integer.MAX_VALUE) {
@@ -331,18 +295,13 @@ public class TimeSeries {
     }
 
     /**
-     * Returns a new time series which is a view of a subset of the current
-     * series.
+     * Returns a new time series which is a view of a subset of the current series.
      * <p>
-     * The new series has begin and end indexes which correspond to the bounds
-     * of the sub-set into the full series.<br>
-     * The tick of the series are shared between the original time series and
-     * the returned one (i.e. no copy).
-     *
+     * The new series has begin and end indexes which correspond to the bounds of the sub-set into the full series.<br>
+     * The tick of the series are shared between the original time series and the returned one (i.e. no copy).
      * @param beginIndex the begin index (inclusive) of the time series
      * @param duration the duration of the time series
-     * @return a constrained {@link TimeSeries time series} which is a sub-set
-     * of the current series
+     * @return a constrained {@link TimeSeries time series} which is a sub-set of the current series
      */
     public TimeSeries subseries(int beginIndex, Period duration) {
 
@@ -372,7 +331,6 @@ public class TimeSeries {
      * Splits the time series into sub-series containing nbTicks ticks each.<br>
      * The current time series is splitted every nbTicks ticks.<br>
      * The last sub-series may have less ticks than nbTicks.
-     *
      * @param nbTicks the number of ticks of each sub-series
      * @return a list of sub-series
      */
@@ -391,7 +349,6 @@ public class TimeSeries {
      * Splits the time series into sub-series lasting sliceDuration.<br>
      * The current time series is splitted every splitDuration.<br>
      * The last sub-series may last less than sliceDuration.
-     *
      * @param splitDuration the duration between 2 splits
      * @param sliceDuration the duration of each sub-series
      * @return a list of sub-series
@@ -413,7 +370,6 @@ public class TimeSeries {
      * Splits the time series into sub-series lasting duration.<br>
      * The current time series is splitted every duration.<br>
      * The last sub-series may last less than duration.
-     *
      * @param duration the duration between 2 splits (and of each sub-series)
      * @return a list of sub-series
      */
@@ -425,7 +381,6 @@ public class TimeSeries {
      * Runs the strategy over the series.
      * <p>
      * Opens the trades with {@link OrderType.BUY} orders.
-     *
      * @param strategy the trading strategy
      * @return the trading record coming from the run
      */
@@ -485,7 +440,7 @@ public class TimeSeries {
                     entryPrice = Decimal.NaN;
                 }
                 if (strategy.shouldOperate(i, tradingRecord)) {
-                    tradingRecord.operate(i, entryPrice, amount);
+                    tradingRecord.operate(i);
                     break;
                 }
             }
@@ -502,7 +457,7 @@ public class TimeSeries {
         for (int i = beginIndex; i < endIndex; i++) {
             // For each tick interval...
             // Looking for the minimum period.
-            long currentPeriodMillis = getTick(i + 1).getEndTime().getMillis() - getTick(i).getEndTime().getMillis();
+            long currentPeriodMillis = getTick(i+1).getEndTime().getMillis() - getTick(i).getEndTime().getMillis();
             if (minPeriod == null) {
                 minPeriod = new Period(currentPeriodMillis);
             } else {
@@ -538,7 +493,6 @@ public class TimeSeries {
 
     /**
      * Builds a list of split indexes from splitDuration.
-     *
      * @param splitDuration the duration between 2 splits
      * @return a list of begin indexes after split
      */

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
@@ -449,7 +449,7 @@ public class TimeSeries {
 
     /**
      * Runs the strategy over the series.
-     *
+     * <p>
      * @param strategy the trading strategy
      * @param orderType the {@link OrderType} used to open the trades
      * @param amount the amount used to open the trades

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
@@ -3,22 +3,23 @@
  *
  * Copyright (c) 2014-2015 Marc de Verdelhan & respective authors (see AUTHORS)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package eu.verdelhan.ta4j;
 
@@ -32,7 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Sequence of {@link Tick ticks} separated by a predefined period (e.g. 15 minutes, 1 day, etc.)
+ * Sequence of {@link Tick ticks} separated by a predefined period (e.g. 15
+ * minutes, 1 day, etc.)
  * <p>
  * Notably, a {@link TimeSeries time series} can be:
  * <ul>
@@ -44,27 +46,46 @@ import org.slf4j.LoggerFactory;
  */
 public class TimeSeries {
 
-    /** The logger */
+    /**
+     * The logger
+     */
     private final Logger log = LoggerFactory.getLogger(getClass());
-    /** Name of the series */
+    /**
+     * Name of the series
+     */
     private final String name;
-    /** Begin index of the time series */
+    /**
+     * Begin index of the time series
+     */
     private int beginIndex = -1;
-    /** End index of the time series */
+    /**
+     * End index of the time series
+     */
     private int endIndex = -1;
-    /** List of ticks */
+    /**
+     * List of ticks
+     */
     private final List<Tick> ticks;
-    /** Time period of the series */
+    /**
+     * Time period of the series
+     */
     private Period timePeriod;
-    /** Maximum number of ticks for the time series */
+    /**
+     * Maximum number of ticks for the time series
+     */
     private int maximumTickCount = Integer.MAX_VALUE;
-    /** Number of removed ticks */
+    /**
+     * Number of removed ticks
+     */
     private int removedTicksCount = 0;
-    /** True if the current series is a sub-series, false otherwise */
+    /**
+     * True if the current series is a sub-series, false otherwise
+     */
     private boolean subSeries = false;
 
     /**
      * Constructor.
+     *
      * @param name the name of the series
      * @param ticks the list of ticks of the series
      */
@@ -74,6 +95,7 @@ public class TimeSeries {
 
     /**
      * Constructor of an unnamed series.
+     *
      * @param ticks the list of ticks of the series
      */
     public TimeSeries(List<Tick> ticks) {
@@ -82,6 +104,7 @@ public class TimeSeries {
 
     /**
      * Constructor.
+     *
      * @param name the name of the series
      * @param timePeriod the time period (between 2 ticks)
      */
@@ -96,6 +119,7 @@ public class TimeSeries {
 
     /**
      * Constructor of an unnamed series.
+     *
      * @param timePeriod the time period (between 2 ticks)
      */
     public TimeSeries(Period timePeriod) {
@@ -104,11 +128,13 @@ public class TimeSeries {
 
     /**
      * Constructor.
+     *
      * @param name the name of the series
      * @param ticks the list of ticks of the series
      * @param beginIndex the begin index (inclusive) of the time series
      * @param endIndex the end index (inclusive) of the time series
-     * @param subSeries true if the current series is a sub-series, false otherwise
+     * @param subSeries true if the current series is a sub-series, false
+     * otherwise
      */
     private TimeSeries(String name, List<Tick> ticks, int beginIndex, int endIndex, boolean subSeries) {
         // TODO: add null checks and out of bounds checks
@@ -193,7 +219,8 @@ public class TimeSeries {
     }
 
     /**
-     * @return the description of the series period (e.g. "from 12:00 21/01/2014 to 12:15 21/01/2014")
+     * @return the description of the series period (e.g. "from 12:00 21/01/2014
+     * to 12:15 21/01/2014")
      */
     public String getSeriesPeriodDescription() {
         StringBuilder sb = new StringBuilder();
@@ -218,8 +245,11 @@ public class TimeSeries {
     /**
      * Sets the maximum number of ticks that will be retained in the series.
      * <p>
-     * If a new tick is added to the series such that the number of ticks will exceed the maximum tick count,
-     * then the FIRST tick in the series is automatically removed, ensuring that the maximum tick count is not exceeded.
+     * If a new tick is added to the series such that the number of ticks will
+     * exceed the maximum tick count, then the FIRST tick in the series is
+     * automatically removed, ensuring that the maximum tick count is not
+     * exceeded.
+     *
      * @param maximumTickCount the maximum tick count
      */
     public void setMaximumTickCount(int maximumTickCount) {
@@ -251,8 +281,10 @@ public class TimeSeries {
      * Adds a tick at the end of the series.
      * <p>
      * Begin index set to 0 if if wasn't initialized.<br>
-     * End index set to 0 if if wasn't initialized, or incremented if it matches the end of the series.<br>
+     * End index set to 0 if if wasn't initialized, or incremented if it matches
+     * the end of the series.<br>
      * Exceeding ticks are removed.
+     *
      * @param tick the tick to be added
      * @see TimeSeries#setMaximumTickCount(int)
      */
@@ -278,13 +310,18 @@ public class TimeSeries {
     }
 
     /**
-     * Returns a new time series which is a view of a subset of the current series.
+     * Returns a new time series which is a view of a subset of the current
+     * series.
      * <p>
-     * The new series has begin and end indexes which correspond to the bounds of the sub-set into the full series.<br>
-     * The tick of the series are shared between the original time series and the returned one (i.e. no copy).
+     * The new series has begin and end indexes which correspond to the bounds
+     * of the sub-set into the full series.<br>
+     * The tick of the series are shared between the original time series and
+     * the returned one (i.e. no copy).
+     *
      * @param beginIndex the begin index (inclusive) of the time series
      * @param endIndex the end index (inclusive) of the time series
-     * @return a constrained {@link TimeSeries time series} which is a sub-set of the current series
+     * @return a constrained {@link TimeSeries time series} which is a sub-set
+     * of the current series
      */
     public TimeSeries subseries(int beginIndex, int endIndex) {
         if (maximumTickCount != Integer.MAX_VALUE) {
@@ -294,16 +331,21 @@ public class TimeSeries {
     }
 
     /**
-     * Returns a new time series which is a view of a subset of the current series.
+     * Returns a new time series which is a view of a subset of the current
+     * series.
      * <p>
-     * The new series has begin and end indexes which correspond to the bounds of the sub-set into the full series.<br>
-     * The tick of the series are shared between the original time series and the returned one (i.e. no copy).
+     * The new series has begin and end indexes which correspond to the bounds
+     * of the sub-set into the full series.<br>
+     * The tick of the series are shared between the original time series and
+     * the returned one (i.e. no copy).
+     *
      * @param beginIndex the begin index (inclusive) of the time series
      * @param duration the duration of the time series
-     * @return a constrained {@link TimeSeries time series} which is a sub-set of the current series
+     * @return a constrained {@link TimeSeries time series} which is a sub-set
+     * of the current series
      */
     public TimeSeries subseries(int beginIndex, Period duration) {
-        
+
         // Calculating the sub-series interval
         DateTime beginInterval = getTick(beginIndex).getEndTime();
         DateTime endInterval = beginInterval.plus(duration);
@@ -322,7 +364,7 @@ public class TimeSeries {
             // --> Incrementing the number of ticks in the subseries
             subseriesNbTicks++;
         }
-        
+
         return subseries(beginIndex, beginIndex + subseriesNbTicks - 1);
     }
 
@@ -330,6 +372,7 @@ public class TimeSeries {
      * Splits the time series into sub-series containing nbTicks ticks each.<br>
      * The current time series is splitted every nbTicks ticks.<br>
      * The last sub-series may have less ticks than nbTicks.
+     *
      * @param nbTicks the number of ticks of each sub-series
      * @return a list of sub-series
      */
@@ -348,6 +391,7 @@ public class TimeSeries {
      * Splits the time series into sub-series lasting sliceDuration.<br>
      * The current time series is splitted every splitDuration.<br>
      * The last sub-series may last less than sliceDuration.
+     *
      * @param splitDuration the duration between 2 splits
      * @param sliceDuration the duration of each sub-series
      * @return a list of sub-series
@@ -369,6 +413,7 @@ public class TimeSeries {
      * Splits the time series into sub-series lasting duration.<br>
      * The current time series is splitted every duration.<br>
      * The last sub-series may last less than duration.
+     *
      * @param duration the duration between 2 splits (and of each sub-series)
      * @return a list of sub-series
      */
@@ -380,6 +425,7 @@ public class TimeSeries {
      * Runs the strategy over the series.
      * <p>
      * Opens the trades with {@link OrderType.BUY} orders.
+     *
      * @param strategy the trading strategy
      * @return the trading record coming from the run
      */
@@ -389,19 +435,41 @@ public class TimeSeries {
 
     /**
      * Runs the strategy over the series.
+     * <p>
+     * Opens the trades with {@link OrderType.BUY} orders.
+     *
      * @param strategy the trading strategy
      * @param orderType the {@link OrderType} used to open the trades
      * @return the trading record coming from the run
      */
     public TradingRecord run(Strategy strategy, OrderType orderType) {
+        return run(strategy, orderType, Decimal.NaN, false);
+
+    }
+
+    /**
+     * Runs the strategy over the series.
+     *
+     * @param strategy the trading strategy
+     * @param orderType the {@link OrderType} used to open the trades
+     * @param amount the amount used to open the trades
+     * @param withEntryPrice store the entry price in the trade record or not
+     * @return the trading record coming from the run
+     */
+    public TradingRecord run(Strategy strategy, OrderType orderType, Decimal amount, Boolean withEntryPrice) {
 
         log.trace("Running strategy: {} (starting with {})", strategy, orderType);
         TradingRecord tradingRecord = new TradingRecord(orderType);
-
+        Decimal entryPrice;
         for (int i = beginIndex; i <= endIndex; i++) {
             // For each tick in the sub-series...
+            if (withEntryPrice) {
+                entryPrice = ticks.get(i).getClosePrice();
+            } else {
+                entryPrice = Decimal.NaN;
+            }
             if (strategy.shouldOperate(i, tradingRecord)) {
-                tradingRecord.operate(i);
+                tradingRecord.operate(i, entryPrice, amount);
             }
         }
 
@@ -411,8 +479,13 @@ public class TimeSeries {
             for (int i = endIndex + 1; i < ticks.size(); i++) {
                 // For each tick out of sub-series bound...
                 // --> Trying to close the last trade
+                if (withEntryPrice) {
+                    entryPrice = ticks.get(i).getClosePrice();
+                } else {
+                    entryPrice = Decimal.NaN;
+                }
                 if (strategy.shouldOperate(i, tradingRecord)) {
-                    tradingRecord.operate(i);
+                    tradingRecord.operate(i, entryPrice, amount);
                     break;
                 }
             }
@@ -429,7 +502,7 @@ public class TimeSeries {
         for (int i = beginIndex; i < endIndex; i++) {
             // For each tick interval...
             // Looking for the minimum period.
-            long currentPeriodMillis = getTick(i+1).getEndTime().getMillis() - getTick(i).getEndTime().getMillis();
+            long currentPeriodMillis = getTick(i + 1).getEndTime().getMillis() - getTick(i).getEndTime().getMillis();
             if (minPeriod == null) {
                 minPeriod = new Period(currentPeriodMillis);
             } else {
@@ -465,6 +538,7 @@ public class TimeSeries {
 
     /**
      * Builds a list of split indexes from splitDuration.
+     *
      * @param splitDuration the duration between 2 splits
      * @return a list of begin indexes after split
      */

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
@@ -279,7 +279,7 @@ public class TradingRecord {
      * @param price the price of the order
      * @param amount the amount to be ordered
      */
-    private void operate(int index, Decimal price, Decimal amount) {
+    public void operate(int index, Decimal price, Decimal amount) {
         if (currentTrade.isClosed()) {
             // Current trade closed, should not occur
             throw new IllegalStateException("Current trade should not be closed");

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/TimeSeriesTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/TimeSeriesTest.java
@@ -23,7 +23,6 @@
 package eu.verdelhan.ta4j;
 
 import eu.verdelhan.ta4j.Order.OrderType;
-import eu.verdelhan.ta4j.analysis.criteria.TotalProfitCriterion;
 import eu.verdelhan.ta4j.mocks.MockTick;
 import eu.verdelhan.ta4j.mocks.MockTimeSeries;
 import eu.verdelhan.ta4j.trading.rules.FixedRule;
@@ -434,7 +433,6 @@ public class TimeSeriesTest {
 
     @Test
     public void runSplitted() {
-        // 1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d 
         List<TimeSeries> subseries = seriesForRun.split(Period.years(1));
 
         List<Trade> trades = subseries.get(0).run(strategy).getTrades();
@@ -447,7 +445,6 @@ public class TimeSeriesTest {
 
         trades = subseries.get(2).run(strategy).getTrades();
         assertEquals(1, trades.size());
-       
         assertEquals(Order.buyAt(6), trades.get(0).getEntry());
         assertEquals(Order.sellAt(7), trades.get(0).getExit());
 

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/TimeSeriesTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/TimeSeriesTest.java
@@ -23,6 +23,7 @@
 package eu.verdelhan.ta4j;
 
 import eu.verdelhan.ta4j.Order.OrderType;
+import eu.verdelhan.ta4j.analysis.criteria.TotalProfitCriterion;
 import eu.verdelhan.ta4j.mocks.MockTick;
 import eu.verdelhan.ta4j.mocks.MockTimeSeries;
 import eu.verdelhan.ta4j.trading.rules.FixedRule;
@@ -383,6 +384,18 @@ public class TimeSeriesTest {
         List<Trade> allTrades = series.run(strategy).getTrades();
         assertEquals(2, allTrades.size());
     }
+    
+    @Test
+    public void runOnWholeSeriesWithAmount() {
+        TimeSeries series = new MockTimeSeries(20d, 40d, 60d, 10d, 30d, 50d, 0d, 20d, 40d);
+
+        List<Trade> allTrades = series.run(strategy,OrderType.BUY, Decimal.HUNDRED, true).getTrades();
+        
+        assertEquals(2, allTrades.size());
+        assertEquals(Decimal.HUNDRED, allTrades.get(0).getEntry().getAmount());
+        assertEquals(Decimal.HUNDRED, allTrades.get(1).getEntry().getAmount());
+
+    }
 
     @Test
     public void runOnSlice() {
@@ -421,6 +434,7 @@ public class TimeSeriesTest {
 
     @Test
     public void runSplitted() {
+        // 1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d 
         List<TimeSeries> subseries = seriesForRun.split(Period.years(1));
 
         List<Trade> trades = subseries.get(0).run(strategy).getTrades();
@@ -433,6 +447,7 @@ public class TimeSeriesTest {
 
         trades = subseries.get(2).run(strategy).getTrades();
         assertEquals(1, trades.size());
+       
         assertEquals(Order.buyAt(6), trades.get(0).getEntry());
         assertEquals(Order.sellAt(7), trades.get(0).getExit());
 


### PR DESCRIPTION
Here we go, my first pull request ... However I think we may want to wait until we fix the subseries:
First you may notice the strange Boolean withEntryPrice in the method signature :
```java
public TradingRecord run(Strategy strategy, OrderType orderType, Decimal amount, Boolean withEntryPrice) ;
```
which is only here as a work around: when set to false, the entry price will not be stored.
Let me explain what happened. When I modified the tests for the timeseries, I had to replace the calls for `Order.buyAt(index)` with `Order.buyAt(index, price, amount)` because now the price was recorded in the trades and `assertEquals(Order.buyAt(index), trades.get(index).getEntry())`  would fail.

Which lead me to a cascading failure on all subseries with index > 0. Here is a test and the output (It'll be clearer)
```java
@Test
    public void splitted(){
        DateTime date = new DateTime();
        TimeSeries series = new MockTimeSeries(new double[]{1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d, 10d},
                    new DateTime[]{date.withYear(2000), date.withYear(2000), date.withYear(2001), date.withYear(2001), date.withYear(2002),
                                   date.withYear(2002), date.withYear(2002), date.withYear(2003), date.withYear(2004), date.withYear(2005)});

        Strategy aStrategy = new Strategy(new FixedRule(0, 3, 5, 7), new FixedRule(2, 4, 6, 9));

        List<TimeSeries> subseries = series.split(Period.years(1));

        /** Output all the subseries to realize that they are not what they should be  :( **/
        for(TimeSeries s: subseries){
            for(int i = 0; i< s.getTickCount(); i++){
            System.out.println(s.getTick(i));
        }
        System.out.println("---");
        }
	}
```	
And the output is not what we would expect:
```text
[time: 31/05/2000 09:39:34, close price: 1.000000]
[time: 31/05/2000 09:39:34, close price: 2.000000]
---
[time: 31/05/2000 09:39:34, close price: 1.000000]
[time: 31/05/2000 09:39:34, close price: 2.000000]
---
[time: 31/05/2000 09:39:34, close price: 1.000000]
[time: 31/05/2000 09:39:34, close price: 2.000000]
[time: 31/05/2001 09:39:34, close price: 3.000000]
---
[time: 31/05/2000 09:39:34, close price: 1.000000]
---
[time: 31/05/2000 09:39:34, close price: 1.000000]
---
[time: 31/05/2000 09:39:34, close price: 1.000000]
---
```
I did not fill an issue on that yet, because I havn't played with the subseries before, so maybe I am doing something wrong. But I think we should investigate the subseries and then remove that withEntryPrice workaround, I mean fix #39 later.
Also I don't understand why the diff is not working in the pull request.
[EDIT]
Ok, I understand why the diff is not working, my IDE change the end of lines and auto adjusted some comments, so re-committed to fix all that. Also I did the pull request straight from the master, not a new branche, I'll need to do that next time. 
