### PR TITLE
BB indicators' multiplier K to be variable

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsLowerIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsLowerIndicator.java
@@ -38,16 +38,25 @@ public class BollingerBandsLowerIndicator extends CachedIndicator<Decimal> {
 
     private final BollingerBandsMiddleIndicator bbm;
 
-    public BollingerBandsLowerIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator) {
+    private final Decimal k;
+
+    public BollingerBandsLowerIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator, Decimal k) {
         // TODO: check for same series between indicators
         super(indicator);
         this.bbm = bbm;
         this.indicator = indicator;
+        this.k = k;
     }
+
+    public BollingerBandsLowerIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator) {
+        this(bbm, indicator, Decimal.TWO);
+    }
+
+    public Decimal getK() { return this.k; }
 
     @Override
     protected Decimal calculate(int index) {
-        return bbm.getValue(index).minus(indicator.getValue(index).multipliedBy(Decimal.TWO));
+        return bbm.getValue(index).minus(indicator.getValue(index).multipliedBy(this.k));
     }
 
     @Override

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsUpperIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsUpperIndicator.java
@@ -38,16 +38,25 @@ public class BollingerBandsUpperIndicator extends CachedIndicator<Decimal> {
 
     private final BollingerBandsMiddleIndicator bbm;
 
-    public BollingerBandsUpperIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator) {
+    private final Decimal k;
+
+    public BollingerBandsUpperIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator, Decimal k) {
         // TODO: check for same series between indicators
         super(indicator);
         this.bbm = bbm;
         this.indicator = indicator;
+        this.k = k;
     }
+
+    public BollingerBandsUpperIndicator(BollingerBandsMiddleIndicator bbm, Indicator<Decimal> indicator) {
+        this(bbm, indicator, Decimal.TWO);
+    }
+
+    public Decimal getK() { return this.k; }
 
     @Override
     protected Decimal calculate(int index) {
-        return bbm.getValue(index).plus(indicator.getValue(index).multipliedBy(Decimal.TWO));
+        return bbm.getValue(index).plus(indicator.getValue(index).multipliedBy(this.k));
     }
 
     @Override

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsLowerIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsLowerIndicatorTest.java
@@ -23,6 +23,8 @@
 package eu.verdelhan.ta4j.indicators.trackers.bollingerbands;
 
 import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+
+import eu.verdelhan.ta4j.Decimal;
 import eu.verdelhan.ta4j.TimeSeries;
 import eu.verdelhan.ta4j.indicators.helpers.StandardDeviationIndicator;
 import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
@@ -56,6 +58,8 @@ public class BollingerBandsLowerIndicatorTest {
         StandardDeviationIndicator standardDeviation = new StandardDeviationIndicator(closePrice, timeFrame);
         BollingerBandsLowerIndicator bblSMA = new BollingerBandsLowerIndicator(bbmSMA, standardDeviation);
 
+        assertDecimalEquals(bblSMA.getK(), 2);
+
         assertDecimalEquals(bblSMA.getValue(0), 1);
         assertDecimalEquals(bblSMA.getValue(1), 0.5);
         assertDecimalEquals(bblSMA.getValue(2), 0.367);
@@ -63,5 +67,17 @@ public class BollingerBandsLowerIndicatorTest {
         assertDecimalEquals(bblSMA.getValue(4), 2.3905);
         assertDecimalEquals(bblSMA.getValue(5), 2.7239);
         assertDecimalEquals(bblSMA.getValue(6), 2.367);
+
+        BollingerBandsLowerIndicator bblSMAwithK = new BollingerBandsLowerIndicator(bbmSMA, standardDeviation, Decimal.valueOf("1.5"));
+
+        assertDecimalEquals(bblSMAwithK.getK(), 1.5);
+
+        assertDecimalEquals(bblSMAwithK.getValue(0), 1);
+        assertDecimalEquals(bblSMAwithK.getValue(1), 0.75);
+        assertDecimalEquals(bblSMAwithK.getValue(2), 0.7752);
+        assertDecimalEquals(bblSMAwithK.getValue(3), 1.7752);
+        assertDecimalEquals(bblSMAwithK.getValue(4), 2.6262);
+        assertDecimalEquals(bblSMAwithK.getValue(5), 2.9595);
+        assertDecimalEquals(bblSMAwithK.getValue(6), 2.7752);
     }
 }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsUpperIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/bollingerbands/BollingerBandsUpperIndicatorTest.java
@@ -23,6 +23,8 @@
 package eu.verdelhan.ta4j.indicators.trackers.bollingerbands;
 
 import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+
+import eu.verdelhan.ta4j.Decimal;
 import eu.verdelhan.ta4j.TimeSeries;
 import eu.verdelhan.ta4j.indicators.helpers.StandardDeviationIndicator;
 import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
@@ -56,6 +58,8 @@ public class BollingerBandsUpperIndicatorTest {
         StandardDeviationIndicator standardDeviation = new StandardDeviationIndicator(closePrice, timeFrame);
         BollingerBandsUpperIndicator bbuSMA = new BollingerBandsUpperIndicator(bbmSMA, standardDeviation);
 
+        assertDecimalEquals(bbuSMA.getK(), 2);
+
         assertDecimalEquals(bbuSMA.getValue(0), 1);
         assertDecimalEquals(bbuSMA.getValue(1), 2.5);
         assertDecimalEquals(bbuSMA.getValue(2), 3.633);
@@ -66,5 +70,20 @@ public class BollingerBandsUpperIndicatorTest {
         assertDecimalEquals(bbuSMA.getValue(7), 5.2761);
         assertDecimalEquals(bbuSMA.getValue(8), 5.633);
         assertDecimalEquals(bbuSMA.getValue(9), 4.2761);
+
+        BollingerBandsUpperIndicator bbuSMAwithK = new BollingerBandsUpperIndicator(bbmSMA, standardDeviation, Decimal.valueOf("1.5"));
+
+        assertDecimalEquals(bbuSMAwithK.getK(), 1.5);
+
+        assertDecimalEquals(bbuSMAwithK.getValue(0), 1);
+        assertDecimalEquals(bbuSMAwithK.getValue(1), 2.25);
+        assertDecimalEquals(bbuSMAwithK.getValue(2), 3.2247);
+        assertDecimalEquals(bbuSMAwithK.getValue(3), 4.2247);
+        assertDecimalEquals(bbuSMAwithK.getValue(4), 4.0404);
+        assertDecimalEquals(bbuSMAwithK.getValue(5), 4.3737);
+        assertDecimalEquals(bbuSMAwithK.getValue(6), 5.2247);
+        assertDecimalEquals(bbuSMAwithK.getValue(7), 5.0404);
+        assertDecimalEquals(bbuSMAwithK.getValue(8), 5.2247);
+        assertDecimalEquals(bbuSMAwithK.getValue(9), 4.0404);
     }
 }


### PR DESCRIPTION
Related to #53

Added a new argument to each BB's constructor
and another new constructor having 2 args for compatibility
whose K is always `Decimal.TWO`.

New field `k` does not have setter
since BB indicators' values are cached in `CachedIndicator`.

Setter can be added if parent has public `clear()` method
but it would not be needed in most cases, AFAIC imagine.