### PR TITLE
[HOTFIX] removed expensive logger initialization for every indicator

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/AbstractIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/AbstractIndicator.java
@@ -24,17 +24,12 @@ package eu.verdelhan.ta4j.indicators;
 
 import eu.verdelhan.ta4j.Indicator;
 import eu.verdelhan.ta4j.TimeSeries;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Abstract {@link Indicator indicator}.
  * <p>
  */
 public abstract class AbstractIndicator<T> implements Indicator<T> {
-
-    /** The logger */
-    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     private TimeSeries series;
 

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
@@ -22,11 +22,15 @@
  */
 package eu.verdelhan.ta4j.indicators;
 
-import eu.verdelhan.ta4j.Indicator;
-import eu.verdelhan.ta4j.TimeSeries;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.TimeSeries;
 
 /**
  * Cached {@link Indicator indicator}.
@@ -34,6 +38,9 @@ import java.util.List;
  * Caches the constructor of the indicator. Avoid to calculate the same index of the indicator twice.
  */
 public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
+    
+    /** The logger */
+    private final static Logger log = LoggerFactory.getLogger(CachedIndicator.class);
 
     /** List of cached results */
     private final List<T> results = new ArrayList<T>();


### PR DESCRIPTION
Fixes #.

Logger initialisation is quite expensive. The current code creates a Logger in the heap for any Indicator since it is referenced in the AbstractIndicator class. The only place where the Logger is actually used is in the CacheIndicator.

Changes proposed in this pull request:
- Removed the final instance in the AbstractIndicator and replaced with a final static indicator in the CacheIndicator class



