### PR TITLE
[HOTFIX] moved expensive decimal constant multiplier to static initialization

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/WilliamsRIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/WilliamsRIndicator.java
@@ -45,6 +45,8 @@ public class WilliamsRIndicator extends CachedIndicator<Decimal> {
     private MaxPriceIndicator maxPriceIndicator;
 
     private MinPriceIndicator minPriceIndicator;
+    
+    private final static Decimal multiplier = Decimal.valueOf("-100");
 
     public WilliamsRIndicator(TimeSeries timeSeries, int timeFrame) {
         this(new ClosePriceIndicator(timeSeries), timeFrame, new MaxPriceIndicator(timeSeries), new MinPriceIndicator(
@@ -70,7 +72,7 @@ public class WilliamsRIndicator extends CachedIndicator<Decimal> {
 
         return ((highestHighPrice.minus(indicator.getValue(index)))
                 .dividedBy(highestHighPrice.minus(lowestLowPrice)))
-                .multipliedBy(Decimal.valueOf("-100"));
+                .multipliedBy(multiplier);
     }
 
     @Override


### PR DESCRIPTION
Fixes #.

Decimal initialisation from Strings is quite expensive. The Williams indicator uses a constant that can be easily statically initialised rather than creating it at runtime.

Changes proposed in this pull request:
- Removed the runtime creation of the Decimal and replaced as a static constant field.



