### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -52,6 +52,8 @@ import ta4jexamples.strategies.MovingMomentumStrategy;
  */
 public class BuyAndSellSignalsToChart {
 
+    private BuyAndSellSignalsToChart() {}
+
     /**
      * Builds a JFreeChart time series from a Ta4j time series and an indicator.
      * @param tickSeries the ta4j time series

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -52,6 +52,8 @@ import ta4jexamples.strategies.MovingMomentumStrategy;
  */
 public class CashFlowToChart {
 
+    private CashFlowToChart() {}
+
     /**
      * Builds a JFreeChart time series from a Ta4j time series and an indicator.
      * @param tickSeries the ta4j time series

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
@@ -44,6 +44,8 @@ public class TradingBotOnMovingTimeSeries {
     /** Close price of the last tick */
     private static Decimal LAST_TICK_CLOSE_PRICE;
 
+    private TradingBotOnMovingTimeSeries() {}
+
     /**
      * Builds a moving time series (i.e. keeping only the maxTickCount last ticks)
      * @param maxTickCount the number of ticks to keep in the time series (at maximum)

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -49,6 +49,8 @@ import ta4jexamples.loaders.CsvTradesLoader;
  */
 public class CandlestickChart {
 
+    private CandlestickChart() {}
+
     /**
      * Builds a JFreeChart OHLC dataset from a ta4j time series.
      * @param series a time series

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -47,6 +47,8 @@ import ta4jexamples.loaders.CsvTicksLoader;
  */
 public class IndicatorsToChart {
 
+    private IndicatorsToChart() {}
+
     /**
      * Builds a JFreeChart time series from a Ta4j time series and an indicator.
      * @param tickSeries the ta4j time series

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTicksLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTicksLoader.java
@@ -44,6 +44,8 @@ public class CsvTicksLoader {
 
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
+    private CsvTicksLoader() {}
+
     /**
      * @return a time series from Apple Inc. ticks.
      */

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -42,6 +42,8 @@ import org.joda.time.Period;
  */
 public class CsvTradesLoader {
 
+    private CsvTradesLoader() {}
+
     /**
      * @return a time series from Bitstamp (bitcoin exchange) trades
      */

--- a/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
@@ -41,7 +41,9 @@ import ta4jexamples.strategies.CCICorrectionStrategy;
 public class StrategyExecutionLogging {
 
     private static final URL LOGBACK_CONF_FILE = StrategyExecutionLogging.class.getClassLoader().getResource("logback-traces.xml");
-    
+
+    private StrategyExecutionLogging() {}
+
     /**
      * Loads the Logback configuration from a resource file.
      * Only here to avoid polluting other examples with logs. Could be replaced by a simple logback.xml file in the resource folder.

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -40,6 +40,8 @@ import ta4jexamples.loaders.CsvTradesLoader;
  */
 public class CCICorrectionStrategy {
 
+    private CCICorrectionStrategy() {}
+
     /**
      * @param series a time series
      * @return a CCI correction strategy

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -46,6 +46,8 @@ public class GlobalExtremaStrategy {
     // We assume that there were at least one trade every 5 minutes during the whole week
     private static final int NB_TICKS_PER_WEEK = 12 * 24 * 7;
 
+    private GlobalExtremaStrategy() {}
+
     /**
      * @param series a time series
      * @return a global extrema strategy

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -45,6 +45,8 @@ import ta4jexamples.loaders.CsvTradesLoader;
  */
 public class MovingMomentumStrategy {
 
+    private MovingMomentumStrategy() {}
+
     /**
      * @param series a time series
      * @return a moving momentum strategy

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -44,6 +44,8 @@ import ta4jexamples.loaders.CsvTradesLoader;
  */
 public class RSI2Strategy {
 
+    private RSI2Strategy() {}
+
     /**
      * @param series a time series
      * @return a 2-period RSI strategy

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -46,6 +46,8 @@ import ta4jexamples.strategies.RSI2Strategy;
  */
 public class WalkForward {
 
+    private WalkForward() {}
+
     /**
      * @param series the time series
      * @return a map (key: strategy, value: name) of trading strategies


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 390 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava