### PR TITLE
Multiple code improvements - squid:S1068, squid:S1197, squid:S2275, squid:RedundantThrowsDeclarationCheck

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTicksLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTicksLoader.java
@@ -77,7 +77,7 @@ public class CsvTicksLoader {
         return new TimeSeries("apple_ticks", ticks);
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         TimeSeries series = CsvTicksLoader.loadAppleIncSeries();
 
         System.out.println("Series: " + series.getName() + " (" + series.getSeriesPeriodDescription() + ")");

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -131,7 +131,7 @@ public class CsvTradesLoader {
         }
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         TimeSeries series = CsvTradesLoader.loadBitstampSeries();
 
         System.out.println("Series: " + series.getName() + " (" + series.getSeriesPeriodDescription() + ")");

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
@@ -297,7 +297,7 @@ public class Tick {
      * @param endTime the end time of the tick
      * @throws IllegalArgumentException if one of the arguments is null
      */
-    private void checkTimeArguments(Period timePeriod, DateTime endTime) throws IllegalArgumentException {
+    private void checkTimeArguments(Period timePeriod, DateTime endTime) {
         if (timePeriod == null) {
             throw new IllegalArgumentException("Time period cannot be null");
         }

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/ParabolicSarIndicator.java
@@ -52,14 +52,11 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Decimal> {
 
     private final HighestValueIndicator highestValueIndicator;
     
-    private final int timeFrame;
-    
     public ParabolicSarIndicator(TimeSeries series, int timeFrame) {
         super(series);
         this.series = series;
         this.lowestValueIndicator = new LowestValueIndicator(new MinPriceIndicator(series), timeFrame);
         this.highestValueIndicator = new HighestValueIndicator(new MaxPriceIndicator(series), timeFrame);
-        this.timeFrame = timeFrame;
     }
 
     @Override

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/WMAIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/WMAIndicator.java
@@ -66,6 +66,6 @@ public class WMAIndicator extends CachedIndicator<Decimal> {
 
     @Override
     public String toString() {
-        return String.format(getClass().getSimpleName() + " timeFrame: %s", timeFrame);
+        return String.format("%s timeFrame: %s", getClass().getSimpleName(), timeFrame);
     }
 }

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volatility/UlcerIndexIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/volatility/UlcerIndexIndicator.java
@@ -42,8 +42,6 @@ public class UlcerIndexIndicator extends CachedIndicator<Decimal> {
     
     private int timeFrame;
 
-    private SMAIndicator sma;
-
     /**
      * Constructor.
      * @param indicator the indicator


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
Please let me know if you have any questions.
George Kankava