### PR TITLE
Adding the PeriodicalGrowthRateIndicator

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicator.java
@@ -1,0 +1,155 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package eu.verdelhan.ta4j.indicators.statistics;
+
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.indicators.CachedIndicator;
+
+
+/**
+ * Periodical Growth Rate indicator.
+ * 
+ * In general the 'Growth Rate' is useful for comparing the average returns of 
+ * investments in stocks or funds and can be used to compare the performance 
+ * e.g. comparing the historical returns of stocks with bonds.
+ * 
+ * This indicator has the following characteristics:
+ *  - the calculation is timeframe dependendant. The timeframe corresponds to the 
+ *    number of trading events in a period, e. g. the timeframe for a US trading 
+ *    year for end of day ticks would be '251' trading days
+ *  - the result is a step function with a constant value within a timeframe
+ *  - NaN values while index is smaller than timeframe, e.g. timeframe is year, 
+ *    than no values are calculated before a full year is reached
+ *  - NaN values for incomplete timeframes, e.g. timeframe is a year and your 
+ *    timeseries contains data for 11,3 years, than no values are calculated for 
+ *    the remaining 0,3 years
+ *  - the method 'getTotalReturn' calculates the total return over all returns 
+ *    of the coresponding timeframes
+ * 
+ * 
+ * Further readings:
+ * Good sumary on 'Rate of Return': https://en.wikipedia.org/wiki/Rate_of_return 
+ * Annual return / CAGR: http://www.investopedia.com/terms/a/annual-return.asp
+ * Annualized Total Return: http://www.investopedia.com/terms/a/annualized-total-return.asp
+ * Annualized Return vs. Cumulative Return: 
+ * http://www.fool.com/knowledge-center/2015/11/03/annualized-return-vs-cumulative-return.aspx
+ * 
+ */
+
+public class PeriodicalGrowthRateIndicator extends CachedIndicator<Decimal> {
+      
+    private final Indicator<Decimal> indicator;
+
+    private final int timeFrame;
+    
+    /**
+     * Constructor.
+     * Example: use timeFrame = 251 and "end of day"-ticks for annual behaviour
+     * in the US (http://tradingsim.com/blog/trading-days-in-a-year/).
+     * @param indicator
+     * @param timeFrame 
+     */
+    public PeriodicalGrowthRateIndicator(Indicator<Decimal> indicator, int timeFrame) {
+        super(indicator);
+        this.indicator = indicator;
+        this.timeFrame = timeFrame;
+    }
+    
+    /**
+     * Gets the TotalReturn from the calculated results of the method 'calculate'.
+     * For a timeFrame = number of trading days within a year (e. g. 251 days in the US) 
+     * and "end of day"-ticks you will get the 'Annualized Total Return'.
+     * Only complete timeFrames are taken into the calculation.
+     * @return 
+     */
+    public double getTotalReturn()
+    {
+
+        Decimal totalProduct = Decimal.ONE;
+        int completeTimeframes = (this.indicator.getTimeSeries().getTickCount()/this.timeFrame); 
+        
+        for (int i = 1; i <= completeTimeframes; i++)
+        {
+            int index = i*this.timeFrame;
+            Decimal currentReturn = this.getValue(index);
+            
+            currentReturn = currentReturn.plus(Decimal.ONE);
+            
+            totalProduct = totalProduct.multipliedBy(currentReturn);
+
+        }
+
+        return (Math.pow(totalProduct.toDouble(),(1.0 /completeTimeframes)));
+             
+    }
+    
+    
+    /**
+     * Do the calculation.
+     * @param index
+     * @return 
+     */
+    @Override
+    protected Decimal calculate(int index) {
+
+        Decimal currentValue = this.indicator.getValue(index);
+        
+        int helpPartialTimeframe = index % this.timeFrame;
+        double helpPartialTimeframeHeld = (double)helpPartialTimeframe / (double)this.timeFrame;
+        
+        double PartialTimeframeHeld;
+        if (helpPartialTimeframeHeld == 0)
+        {
+            PartialTimeframeHeld = 1.0;
+        }
+        else
+        {
+            PartialTimeframeHeld = helpPartialTimeframeHeld;
+        }
+        
+        // Avoid calculations of returns if index number is below timeframe
+        // e.g. timeframe = 365, index = 5 => no calculation 
+        Decimal timeframedReturn = Decimal.NaN;
+        Decimal movingSimpleReturn = Decimal.NaN;
+        if (index >= this.timeFrame)
+        {
+            if (PartialTimeframeHeld == 1.0)
+            {    
+                
+                Decimal movingValue = this.indicator.getValue(index - this.timeFrame);
+                movingSimpleReturn = (currentValue.minus(movingValue)).dividedBy(movingValue);
+
+                double timeframedReturn_double = Math.pow((1 + movingSimpleReturn.toDouble()),(1/PartialTimeframeHeld)) - 1;
+                timeframedReturn = Decimal.valueOf(timeframedReturn_double);
+            
+            }
+            
+        }
+
+        return timeframedReturn;
+       
+        
+    }
+}
+

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
@@ -23,10 +23,14 @@
 package eu.verdelhan.ta4j.indicators.statistics;
 
 import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Rule;
+import eu.verdelhan.ta4j.Strategy;
 import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
 import eu.verdelhan.ta4j.TimeSeries;
 import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
 import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import eu.verdelhan.ta4j.trading.rules.CrossedDownIndicatorRule;
+import eu.verdelhan.ta4j.trading.rules.CrossedUpIndicatorRule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Before;
@@ -61,7 +65,7 @@ public class PeriodicalGrowthRateIndicatorTest {
     @Test
     public void testGetTotalReturn() { 
         PeriodicalGrowthRateIndicator gri = new PeriodicalGrowthRateIndicator(this.closePrice,5);
-        double expResult = 0.9683;
+        double expResult = 0.9564;
         double result = gri.getTotalReturn();
         assertEquals(expResult, result,0.01);
 
@@ -78,9 +82,36 @@ public class PeriodicalGrowthRateIndicatorTest {
         assertEquals(gri.getValue(0), Decimal.NaN);
         assertEquals(gri.getValue(4), Decimal.NaN);
         assertDecimalEquals(gri.getValue(5), -0.0268);
+        assertDecimalEquals(gri.getValue(6), 0.0541);
         assertDecimalEquals(gri.getValue(10), -0.0495);
-        assertEquals(gri.getValue(28), Decimal.NaN);
+        assertDecimalEquals(gri.getValue(21), 0.2009);
+        assertDecimalEquals(gri.getValue(24), 0.0220);
+        assertEquals(gri.getValue(25), Decimal.NaN);
+        assertEquals(gri.getValue(26), Decimal.NaN);
     }
+    
+    /**
+     * Test if rules & strategies are working with NaN-Values
+     */
+    @Test
+    public void testStrategies() { 
+        
+        PeriodicalGrowthRateIndicator gri = new PeriodicalGrowthRateIndicator(this.closePrice,5);
+
+        // Rules
+        Rule buyingRule = new CrossedUpIndicatorRule(gri,Decimal.valueOf("0.0")); 
+        Rule sellingRule = new CrossedDownIndicatorRule(gri,Decimal.valueOf("0.0"));     
+        
+        Strategy strategy = new Strategy(buyingRule, sellingRule);
+                
+        // Check trades
+        int result = mockdata.run(strategy).getTradeCount();             
+        int expResult = 3;
+        
+        assertEquals(expResult, result,0.01);
+   
+    }
+
     
 
     

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
@@ -1,0 +1,87 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package eu.verdelhan.ta4j.indicators.statistics;
+
+import eu.verdelhan.ta4j.Decimal;
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
+import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+
+public class PeriodicalGrowthRateIndicatorTest {
+
+    private TimeSeries mockdata;
+    
+    private ClosePriceIndicator closePrice;
+    
+    public PeriodicalGrowthRateIndicatorTest() {
+    }
+    
+    @Before
+    public void setUp() {
+        mockdata = new MockTimeSeries(
+                                  29.49,28.30,27.74,27.65,27.60,28.70,28.60,
+                                  28.19,27.40,27.20,27.28,27.00,27.59,26.20,
+                                  25.75,24.75,23.33,24.45,24.25,25.02,23.60,
+                                  24.20,24.28,25.70,25.46,25.10,25.00,25.00,
+                                  25.85);
+        closePrice = new ClosePriceIndicator(mockdata);
+
+    }
+
+
+    
+    /**
+     * Test of total return calculation
+     */
+    @Test
+    public void testGetTotalReturn() { 
+        PeriodicalGrowthRateIndicator gri = new PeriodicalGrowthRateIndicator(this.closePrice,5);
+        double expResult = 0.9683;
+        double result = gri.getTotalReturn();
+        assertEquals(expResult, result,0.01);
+
+    }
+    
+
+    /**
+     * Test of calculation
+     */
+    @Test
+    public void testCalculationMode1() { 
+        PeriodicalGrowthRateIndicator gri = new PeriodicalGrowthRateIndicator(this.closePrice,5);
+        
+        assertEquals(gri.getValue(0), Decimal.NaN);
+        assertEquals(gri.getValue(4), Decimal.NaN);
+        assertDecimalEquals(gri.getValue(5), -0.0268);
+        assertDecimalEquals(gri.getValue(10), -0.0495);
+        assertEquals(gri.getValue(28), Decimal.NaN);
+    }
+    
+
+    
+}


### PR DESCRIPTION
Adds a Growth Rate indicator as discussed in #89 with a test file.

In general the 'Growth Rate' is useful for comparing the average returns of investments and may be used to compare the performance.

It implements:
- The calculation of the indicator which respects a specific timeframe.
- A method to calculate the total return. Choosing the correct timeframe and the corresponding tick data it calculates the 'Annualized Total Return'. 