### PR TITLE
Apache Spark support

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Decimal.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Decimal.java
@@ -22,6 +22,7 @@
  */
 package eu.verdelhan.ta4j;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
@@ -35,9 +36,11 @@ import java.math.RoundingMode;
  * @see MathContext
  * @see RoundingMode
  */
-public final class Decimal implements Comparable<Decimal> {
+public final class Decimal implements Comparable<Decimal>, Serializable {
 
-    public static final MathContext MATH_CONTEXT = new MathContext(32, RoundingMode.HALF_UP);
+	private static final long serialVersionUID = 2225130444465033658L;
+
+	public static final MathContext MATH_CONTEXT = new MathContext(32, RoundingMode.HALF_UP);
 
     /** Not-a-Number instance (infinite error) */
     public static final Decimal NaN = new Decimal();

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Indicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Indicator.java
@@ -22,13 +22,15 @@
  */
 package eu.verdelhan.ta4j;
 
+import java.io.Serializable;
+
 /**
  * Indicator over a {@link TimeSeries time series}.
  * <p>
  * For each index of the time series, returns a value of type <b>T</b>.
  * @param <T> the type of returned value (Double, Boolean, etc.)
  */
-public interface Indicator<T> {
+public interface Indicator<T> extends Serializable {
 
     /**
      * @param index the tick index

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Order.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Order.java
@@ -22,6 +22,8 @@
  */
 package eu.verdelhan.ta4j;
 
+import java.io.Serializable;
+
 /**
  * An order.
  * <p>
@@ -34,9 +36,11 @@ package eu.verdelhan.ta4j;
  * </ul>
  * A {@link Trade trade} is a pair of complementary orders.
  */
-public class Order {
+public class Order implements Serializable {
 
-    /**
+	private static final long serialVersionUID = -905474949010114150L;
+
+	/**
      * The type of an {@link Order order}.
      * <p>
      * A BUY corresponds to a <i>BID</i> order.<p>

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
@@ -23,6 +23,8 @@
 package eu.verdelhan.ta4j;
 
 
+import java.io.Serializable;
+
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
@@ -30,9 +32,10 @@ import org.joda.time.Period;
  * End tick of a time period.
  * <p>
  */
-public class Tick {
+public class Tick implements Serializable {
 
-    /** Time period (e.g. 1 day, 15 min, etc.) of the tick */
+	private static final long serialVersionUID = 8038383777467488147L;
+	/** Time period (e.g. 1 day, 15 min, etc.) of the tick */
     private Period timePeriod;
     /** End time of the tick */
     private DateTime endTime;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TimeSeries.java
@@ -23,6 +23,8 @@
 package eu.verdelhan.ta4j;
 
 import eu.verdelhan.ta4j.Order.OrderType;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -42,9 +44,10 @@ import org.slf4j.LoggerFactory;
  * <li>used to run {@link Strategy trading strategies}
  * </ul>
  */
-public class TimeSeries {
+public class TimeSeries implements Serializable {
 
-    /** The logger */
+	private static final long serialVersionUID = -1878027009398790126L;
+	/** The logger */
     private final Logger log = LoggerFactory.getLogger(getClass());
     /** Name of the series */
     private final String name;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Trade.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Trade.java
@@ -22,6 +22,8 @@
  */
 package eu.verdelhan.ta4j;
 
+import java.io.Serializable;
+
 import eu.verdelhan.ta4j.Order.OrderType;
 
 /**
@@ -32,9 +34,11 @@ import eu.verdelhan.ta4j.Order.OrderType;
  *   entry == BUY --> exit == SELL
  *   entry == SELL --> exit == BUY
  */
-public class Trade {
+public class Trade implements Serializable {
 
-    /** The entry order */
+	private static final long serialVersionUID = -5484709075767220358L;
+
+	/** The entry order */
     private Order entry;
 
     /** The exit order */

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/TradingRecord.java
@@ -23,6 +23,8 @@
 package eu.verdelhan.ta4j;
 
 import eu.verdelhan.ta4j.Order.OrderType;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,9 +38,11 @@ import java.util.List;
  * <li>analyze the performance of a trading strategy
  * </ul>
  */
-public class TradingRecord {
+public class TradingRecord implements Serializable {
 
-    /** The recorded orders */
+	private static final long serialVersionUID = -4436851731855891220L;
+
+	/** The recorded orders */
     private List<Order> orders = new ArrayList<Order>();
     
     /** The recorded BUY orders */


### PR DESCRIPTION
As of now, ta4j doesn't support executing simulations on a spark cluster because none of the models can be serialized. This adds serialization to everything needed to run a simulation on a cluster

