### PR TITLE
Defect Fix: CachedIndicator Infinite Recursion

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
@@ -84,7 +84,7 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
             highestResultIndex = removedTicksCount;
             result = results.get(0);
             if (result == null) {
-                result = calculate(removedTicksCount);
+                result = calculate(0);
                 results.set(0, result);
             }
         } else {


### PR DESCRIPTION
Fixes #120 .

Changes proposed in this pull request:
- In the base case, we calculate the 0-index result instead of the number of removed ticks (which was never decremented leading to infinite recursion)
- Added a test which demonstrated the stack over flow exception scenario. The above change passes the test.



