### PR TITLE
Adding Smoothed RSI Indicator based on Wilders calculation

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculation.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculation.java
@@ -1,0 +1,41 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.indicators.CachedIndicator;
+
+/**
+ * Relative Strength Index calculation
+ * <p>
+ */
+public class RelativeStrengthIndexCalculation extends CachedIndicator<Decimal> {
+
+    private Indicator<Decimal> averageGainIndicator;
+    private Indicator<Decimal> averageLossIndicator;
+
+    public RelativeStrengthIndexCalculation(Indicator<Decimal> avgGain, Indicator<Decimal> avgLoss) {
+        // TODO: check if up series is equal to low series
+        super(avgGain);
+        averageGainIndicator = avgGain;
+        averageLossIndicator = avgLoss;
+    }
+
+    @Override
+    protected Decimal calculate(int index) {
+        if (index == 0) {
+            return Decimal.ZERO;
+        }
+
+        // Relative strength
+        Decimal averageLoss = averageLossIndicator.getValue(index);
+        if (averageLoss.isZero()) {
+            return Decimal.HUNDRED;
+        }
+        Decimal averageGain = averageGainIndicator.getValue(index);
+        Decimal relativeStrength = averageGain.dividedBy(averageLoss);
+
+        // Nominal case
+        Decimal ratio = Decimal.HUNDRED.dividedBy(Decimal.ONE.plus(relativeStrength));
+        return Decimal.HUNDRED.minus(ratio);
+    }
+}

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculation.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculation.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicator.java
@@ -1,0 +1,40 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.indicators.RecursiveCachedIndicator;
+
+/**
+ * Average gain indicator calculated using smoothing
+ * <p>
+ */
+public class SmoothedAverageGainIndicator extends RecursiveCachedIndicator<Decimal> {
+
+    private final AverageGainIndicator averageGains;
+    private final Indicator<Decimal> indicator;
+
+    private final int timeFrame;
+
+    public SmoothedAverageGainIndicator(Indicator<Decimal> indicator, int timeFrame) {
+        super(indicator);
+        this.indicator = indicator;
+        this.averageGains = new AverageGainIndicator(indicator, timeFrame);
+        this.timeFrame = timeFrame;
+    }
+
+    @Override
+    protected Decimal calculate(int index) {
+        if(index > timeFrame) {
+            return getValue(index - 1)
+                .multipliedBy(Decimal.valueOf(timeFrame - 1))
+                .plus(calculateGain(index))
+                .dividedBy(Decimal.valueOf(timeFrame));
+        }
+        return averageGains.getValue(index);
+    }
+
+    private Decimal calculateGain(int index){
+        Decimal gain = indicator.getValue(index).minus(indicator.getValue(index - 1));
+        return gain.isPositive() ? gain : Decimal.ZERO;
+    }
+}

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicator.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicator.java
@@ -1,0 +1,40 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.indicators.RecursiveCachedIndicator;
+
+/**
+ * Average loss indicator calculated using smoothing
+ * <p>
+ */
+public class SmoothedAverageLossIndicator extends RecursiveCachedIndicator<Decimal> {
+
+    private final AverageLossIndicator averageLosses;
+    private final Indicator<Decimal> indicator;
+
+    private final int timeFrame;
+
+    public SmoothedAverageLossIndicator(Indicator<Decimal> indicator, int timeFrame) {
+        super(indicator);
+        this.indicator = indicator;
+        this.averageLosses = new AverageLossIndicator(indicator, timeFrame);
+        this.timeFrame = timeFrame;
+    }
+
+    @Override
+    protected Decimal calculate(int index) {
+        if (index > timeFrame) {
+            return getValue(index - 1)
+                .multipliedBy(Decimal.valueOf(timeFrame - 1))
+                .plus(calculateLoss(index))
+                .dividedBy(Decimal.valueOf(timeFrame));
+        }
+        return averageLosses.getValue(index);
+    }
+
+    private Decimal calculateLoss(int index) {
+        Decimal loss = indicator.getValue(index).minus(indicator.getValue(index - 1));
+        return loss.isNegative() ? loss.abs() : Decimal.ZERO;
+    }
+}

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicator.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicator.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.trackers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicator.java
@@ -1,0 +1,52 @@
+package eu.verdelhan.ta4j.indicators.trackers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.indicators.CachedIndicator;
+import eu.verdelhan.ta4j.indicators.helpers.*;
+
+/**
+ * Relative strength index indicator.
+ * <p>
+ * This calculation of RSI is based on accumulative moving average
+ * as described in Wilder's original paper from 1978
+ *
+ * <p>See reference
+ * <a href="http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:relative_strength_index_rsi">
+ * RSI calculation</a>.
+ *
+ * @see RSIIndicator
+ * @since 0.9
+ */
+public class SmoothedRSIIndicator extends CachedIndicator<Decimal> {
+
+    private static final Integer SMOOTH_MIN_TICKS = 150;
+
+    private RelativeStrengthIndexCalculation rsiCalculation;
+    private final int timeFrame;
+
+    public SmoothedRSIIndicator(Indicator<Decimal> indicator, int timeFrame) {
+        super(indicator);
+        this.timeFrame = timeFrame;
+        rsiCalculation = new RelativeStrengthIndexCalculation(
+            new SmoothedAverageGainIndicator(indicator, timeFrame),
+            new SmoothedAverageLossIndicator(indicator, timeFrame)
+        );
+    }
+
+    @Override
+    protected Decimal calculate(int index) {
+        if (index < SMOOTH_MIN_TICKS) {
+            log.warn(
+                "Requesting index : {}. Smoothed RSI needs {} ticks before calculated index in data series to get the best results",
+                index,
+                SMOOTH_MIN_TICKS);
+        }
+        return rsiCalculation.getValue(index);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + " timeFrame: " + timeFrame;
+    }
+}

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/TATestsUtils.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/TATestsUtils.java
@@ -23,6 +23,7 @@
 package eu.verdelhan.ta4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Utility class for {@code Decimal} tests.
@@ -60,5 +61,15 @@ public class TATestsUtils {
      */
     public static void assertDecimalEquals(Decimal actual, double expected) {
         assertEquals(expected, actual.toDouble(), TA_OFFSET);
+    }
+
+    /**
+     * Verifies that the actual {@code Decimal} value is not equal to the given {@code Integer} representation.
+     * @param actual the actual {@code Decimal} value
+     * @param unexpected the given {@code Integer} representation to compare the actual value to
+     * @throws AssertionError if the actual value is equal to the given {@code Integer} representation
+     */
+    public static void assertDecimalNotEquals(Decimal actual, int unexpected) {
+        assertNotEquals(Decimal.valueOf(unexpected), actual);
     }
 }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/AverageLossIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/AverageLossIndicatorTest.java
@@ -54,7 +54,7 @@ public class AverageLossIndicatorTest {
     }
 
     @Test
-    public void averageLossMustReturnZeroWhenTheDataDoesntGain() {
+    public void averageLossMustReturnZeroWhenTheDataGain() {
         AverageLossIndicator averageLoss = new AverageLossIndicator(new ClosePriceIndicator(data), 4);
         assertDecimalEquals(averageLoss.getValue(3), 0);
     }
@@ -66,7 +66,7 @@ public class AverageLossIndicatorTest {
     }
 
     @Test
-    public void averageGainWhenIndexIsZeroMustBeZero() {
+    public void averageLossWhenIndexIsZeroMustBeZero() {
         AverageLossIndicator averageLoss = new AverageLossIndicator(new ClosePriceIndicator(data), 10);
         assertDecimalEquals(averageLoss.getValue(0), 0);
     }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculationTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculationTest.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculationTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/RelativeStrengthIndexCalculationTest.java
@@ -1,0 +1,59 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
+import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import org.junit.Before;
+import org.junit.Test;
+
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+import static org.junit.Assert.assertEquals;
+
+public class RelativeStrengthIndexCalculationTest {
+
+    private TimeSeries gains;
+    private TimeSeries losses;
+
+    @Before
+    public void prepare() {
+        gains = new MockTimeSeries(1, 1, 0.8, 0.84, 0.672, 0.5376, 0.43008);
+        losses = new MockTimeSeries(2, 0, 0.2, 0.16, 0.328, 0.4624, 0.36992);
+    }
+
+    @Test
+    public void rsiCalculationFromMockedGainsAndLosses() {
+        RelativeStrengthIndexCalculation rsiCalc = new RelativeStrengthIndexCalculation(
+            new ClosePriceIndicator(gains),
+            new ClosePriceIndicator(losses)
+        );
+
+        assertDecimalEquals(rsiCalc.getValue(2), 80.0);
+        assertDecimalEquals(rsiCalc.getValue(3), 84.0);
+        assertDecimalEquals(rsiCalc.getValue(4), 67.2);
+        assertDecimalEquals(rsiCalc.getValue(5), 53.76);
+        assertDecimalEquals(rsiCalc.getValue(6), 53.76);
+
+    }
+
+    @Test
+    public void rsiCalcFirstValueShouldBeZero() {
+        RelativeStrengthIndexCalculation rsiCalc = new RelativeStrengthIndexCalculation(
+            new ClosePriceIndicator(gains),
+            new ClosePriceIndicator(losses)
+        );
+
+        assertEquals(Decimal.ZERO, rsiCalc.getValue(0));
+    }
+
+    @Test
+    public void rsiCalcHundredIfNoLoss() {
+        RelativeStrengthIndexCalculation rsiCalc = new RelativeStrengthIndexCalculation(
+            new ClosePriceIndicator(gains),
+            new ClosePriceIndicator(losses)
+        );
+
+        assertEquals(Decimal.HUNDRED, rsiCalc.getValue(1));
+    }
+
+}

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicatorTest.java
@@ -1,0 +1,52 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
+import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import org.junit.Before;
+import org.junit.Test;
+
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalNotEquals;
+
+public class SmoothedAverageGainIndicatorTest {
+
+    private TimeSeries data;
+
+    @Before
+    public void prepare() {
+        data = new MockTimeSeries(1, 2, 3, 4, 3, 4, 5, 4, 3, 3, 4, 3, 2);
+    }
+
+    @Test
+    public void smoothedAverageGainUsingTimeFrame5UsingClosePrice() {
+        SmoothedAverageGainIndicator averageGain = new SmoothedAverageGainIndicator(new ClosePriceIndicator(data), 5);
+
+        assertDecimalEquals(averageGain.getValue(5), "0.8");
+        assertDecimalEquals(averageGain.getValue(6), "0.84");
+        assertDecimalEquals(averageGain.getValue(7), "0.672");
+        assertDecimalEquals(averageGain.getValue(8), "0.5376");
+        assertDecimalEquals(averageGain.getValue(9), "0.43008");
+        assertDecimalEquals(averageGain.getValue(10), "0.544064");
+        assertDecimalEquals(averageGain.getValue(11), "0.4352512");
+        assertDecimalEquals(averageGain.getValue(12), "0.34820096");
+    }
+
+    @Test
+    public void smoothedAverageGainMustReturnNonZeroWhenDataGainedAtLeastOnce() {
+        SmoothedAverageGainIndicator averageGain = new SmoothedAverageGainIndicator(new ClosePriceIndicator(data), 3);
+        assertDecimalNotEquals(averageGain.getValue(9), 0);
+    }
+
+    @Test
+    public void smoothedAverageGainWhenTimeFrameIsGreaterThanIndicatorDataShouldBeCalculatedWithDataSize() {
+        SmoothedAverageGainIndicator averageGain = new SmoothedAverageGainIndicator(new ClosePriceIndicator(data), 1000);
+        assertDecimalEquals(averageGain.getValue(12), 6d / data.getTickCount());
+    }
+
+    @Test
+    public void smoothedAverageGainWhenIndexIsZeroMustBeZero() {
+        SmoothedAverageGainIndicator averageGain = new SmoothedAverageGainIndicator(new ClosePriceIndicator(data), 10);
+        assertDecimalEquals(averageGain.getValue(0), 0);
+    }
+}

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageGainIndicatorTest.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.TimeSeries;

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicatorTest.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.helpers;
 
 import eu.verdelhan.ta4j.TimeSeries;

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/helpers/SmoothedAverageLossIndicatorTest.java
@@ -1,0 +1,58 @@
+package eu.verdelhan.ta4j.indicators.helpers;
+
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
+import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import org.junit.Before;
+import org.junit.Test;
+
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalNotEquals;
+
+public class SmoothedAverageLossIndicatorTest {
+
+    private TimeSeries data;
+
+    @Before
+    public void setUp() {
+        data = new MockTimeSeries(1, 2, 3, 4, 3, 4, 5, 4, 3, 3, 4, 3, 2);
+    }
+
+    @Test
+    public void smoothedAverageLossUsingTimeFrame5UsingClosePrice() {
+        SmoothedAverageLossIndicator averageLoss = new SmoothedAverageLossIndicator(new ClosePriceIndicator(data), 5);
+
+        assertDecimalEquals(averageLoss.getValue(5), "0.2");
+        assertDecimalEquals(averageLoss.getValue(6), "0.16");
+        assertDecimalEquals(averageLoss.getValue(7), "0.328");
+        assertDecimalEquals(averageLoss.getValue(8), "0.4624");
+        assertDecimalEquals(averageLoss.getValue(9), "0.36992");
+        assertDecimalEquals(averageLoss.getValue(10), "0.295936");
+        assertDecimalEquals(averageLoss.getValue(11), "0.4367488");
+        assertDecimalEquals(averageLoss.getValue(12), "0.54939904");
+    }
+
+    @Test
+    public void smoothedAverageLossMustReturnZeroWhenPrecedingDataOnlyGain() {
+        SmoothedAverageLossIndicator averageLoss = new SmoothedAverageLossIndicator(new ClosePriceIndicator(data), 4);
+        assertDecimalEquals(averageLoss.getValue(3), 0);
+    }
+
+    @Test
+    public void smoothedAverageLossMustReturnNonZeroWhenDataLossAtLeastOnce() {
+        SmoothedAverageLossIndicator averageLoss = new SmoothedAverageLossIndicator(new ClosePriceIndicator(data), 2);
+        assertDecimalNotEquals(averageLoss.getValue(6), 0);
+    }
+
+    @Test
+    public void smoothedAverageLossWhenTimeFrameIsGreaterThanIndex() {
+        SmoothedAverageLossIndicator averageLoss = new SmoothedAverageLossIndicator(new ClosePriceIndicator(data), 1000);
+        assertDecimalEquals(averageLoss.getValue(12), 5d / data.getTickCount());
+    }
+
+    @Test
+    public void smoothedAverageLossWhenIndexIsZeroMustBeZero() {
+        AverageLossIndicator averageLoss = new AverageLossIndicator(new ClosePriceIndicator(data), 10);
+        assertDecimalEquals(averageLoss.getValue(0), 0);
+    }
+}

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicatorTest.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package eu.verdelhan.ta4j.indicators.trackers;
 
 import eu.verdelhan.ta4j.Decimal;

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/trackers/SmoothedRSIIndicatorTest.java
@@ -1,0 +1,62 @@
+package eu.verdelhan.ta4j.indicators.trackers;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.simple.ClosePriceIndicator;
+import eu.verdelhan.ta4j.mocks.MockTimeSeries;
+import org.junit.Before;
+import org.junit.Test;
+
+import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SmoothedRSIIndicatorTest {
+
+    private TimeSeries data;
+
+    @Before
+    public void setUp() {
+        data = new MockTimeSeries(
+            50.45, 50.30, 50.20,
+            50.15, 50.05, 50.06,
+            50.10, 50.08, 50.03,
+            50.07, 50.01, 50.14,
+            50.22, 50.43, 50.50,
+            50.56, 50.52, 50.70,
+            50.55, 50.62, 50.90,
+            50.82, 50.86, 51.20, 51.30, 51.10);
+    }
+
+    @Test
+    public void rsiUsingTimeFrame14UsingClosePrice() {
+        SmoothedRSIIndicator rsi = new SmoothedRSIIndicator(new ClosePriceIndicator(data), 2);
+
+        assertDecimalEquals(rsi.getValue(2), 0.0);
+        assertDecimalEquals(rsi.getValue(3), 0.0);
+        assertDecimalEquals(rsi.getValue(4), 0.0);
+        assertDecimalEquals(rsi.getValue(5), 9.638554217);
+        assertDecimalEquals(rsi.getValue(6), 48.97959184);
+        assertDecimalEquals(rsi.getValue(7), 34.12322275);
+        assertDecimalEquals(rsi.getValue(8), 13.55932203);
+        assertDecimalEquals(rsi.getValue(9), 55.99232982);
+        assertDecimalEquals(rsi.getValue(10), 22.64443583);
+        assertDecimalEquals(rsi.getValue(11), 78.39740119);
+        assertDecimalEquals(rsi.getValue(12), 88.55224651);
+    }
+
+    @Test
+    public void smoothedRsiFirstValueShouldBeZero() {
+        SmoothedRSIIndicator rsi = new SmoothedRSIIndicator(new ClosePriceIndicator(data), 14);
+
+        assertEquals(Decimal.ZERO, rsi.getValue(0));
+    }
+
+    @Test
+    public void smoothedRsiIsNeverHundredIfLossPresentInDataSeries() {
+        SmoothedRSIIndicator rsi = new SmoothedRSIIndicator(new ClosePriceIndicator(data), 3);
+
+        assertNotEquals(Decimal.HUNDRED, rsi.getValue(14));
+        assertNotEquals(Decimal.HUNDRED, rsi.getValue(15));
+    }
+}


### PR DESCRIPTION
Fixes #90 .

Changes proposed in this pull request:
- new SmoothedRSIIndicator based on original Wilders calculation using accumulative moving average
- RSI calculation code to new indicator RelativeStrengthIndexCalculation.class, to be shared with both (smoothed and non-smoothed) RSI calculations
- updated javadocs
- added unit tests


