### PR TITLE
Change DateTimeFormatter.ISO_DATE to ISO_DATE_TIME

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/Tick.java
@@ -287,14 +287,14 @@ public class Tick implements Serializable {
      * @return a human-friendly string of the end timestamp
      */
     public String getDateName() {
-        return endTime.format(DateTimeFormatter.ISO_DATE);
+        return endTime.format(DateTimeFormatter.ISO_DATE_TIME);
     }
 
     /**
      * @return a even more human-friendly string of the end timestamp
      */
     public String getSimpleDateName() {
-        return endTime.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        return endTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 
     /**


### PR DESCRIPTION
- Change getDateName() DateTimeFormatter from "ISO_DATE" to "ISO_DATE_TIME" (because "date" AND "time" is needed)
- Change getSimpleDateName() DateTimeFormatter from "ISO_LOCAL_DATE" to "ISO_LOCAL_DATE_TIME" (because "date" AND "time" is needed)


Fixes #.

Changes proposed in this pull request:
- 
- 
- 


