### PR TITLE
Adding 'PreviousValueIndicator' to the library.

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/simple/PreviousValueIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/simple/PreviousValueIndicator.java
@@ -1,0 +1,61 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package eu.verdelhan.ta4j.indicators.simple;
+
+import eu.verdelhan.ta4j.Decimal;
+import eu.verdelhan.ta4j.Indicator;
+import eu.verdelhan.ta4j.indicators.CachedIndicator;
+
+/**
+ * Returns the previous (n-th) value of an indicator
+ * <p>
+ */
+public class PreviousValueIndicator extends CachedIndicator<Decimal> {
+
+    private int n;
+    private Indicator<Decimal> indicator;
+
+    /**
+     * Constructor.
+     * @param indicator the indicator of which the previous value should be calculated
+     */
+    public PreviousValueIndicator(Indicator<Decimal> indicator) {
+        this(indicator,1);
+    }
+
+    /**
+     * Constructor.
+     * @param indicator the indicator of which the previous value should be calculated
+     * @param n parameter defines the previous n-th value
+     */
+    public PreviousValueIndicator(Indicator<Decimal> indicator, int n){
+        super(indicator);
+        this.n = n;
+        this.indicator = indicator;
+    }
+
+    protected Decimal calculate(int index) {
+        int previousValue = Math.max(0, (index-n));
+        return this.indicator.getValue(previousValue);
+    }
+}

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/simple/PreviousValueIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/simple/PreviousValueIndicatorTest.java
@@ -1,0 +1,140 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan & respective authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package eu.verdelhan.ta4j.indicators.simple;
+
+import eu.verdelhan.ta4j.Tick;
+import eu.verdelhan.ta4j.TimeSeries;
+import eu.verdelhan.ta4j.indicators.trackers.EMAIndicator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class PreviousValueIndicatorTest {
+    private PreviousValueIndicator prevValueIndicator;
+
+    private PreviousPriceIndicator prevPriceIndicator;
+    private ClosePriceIndicator closePriceIndicator;
+    private OpenPriceIndicator openPriceIndicator;
+    private MinPriceIndicator minPriceIndicator;
+    private MaxPriceIndicator maxPriceIndicator;
+
+    private VolumeIndicator volumeIndicator;
+    private EMAIndicator emaIndicator;
+
+    private TimeSeries series;
+
+    @Before
+    public void setUp(){
+        Random r = new Random();
+        List<Tick> ticks = new ArrayList<>();
+        for (int i = 0; i < 1000; i++){
+            double open = r.nextDouble();
+            double close = r.nextDouble();
+            double max = Math.max(close+r.nextDouble(), open+r.nextDouble());
+            double min = Math.min(0, Math.min(close-r.nextDouble(), open-r.nextDouble()));
+            ZonedDateTime dateTime = ZonedDateTime.now();
+            Tick tick = new Tick(dateTime, open, close, max, min, i);
+            ticks.add(tick);
+        }
+        this.series = new TimeSeries("test", ticks);
+
+        this.prevPriceIndicator = new PreviousPriceIndicator(this.series);
+        this.openPriceIndicator = new OpenPriceIndicator(this.series);
+        this.minPriceIndicator = new MinPriceIndicator(this.series);
+        this.maxPriceIndicator = new MaxPriceIndicator(this.series);
+        this.volumeIndicator = new VolumeIndicator(this.series);
+        this.closePriceIndicator = new ClosePriceIndicator(this.series);
+        this.emaIndicator = new EMAIndicator(this.closePriceIndicator, 20);
+    }
+
+    @Test
+    public void shouldBeSameValueAsPreviousPriceIndicator(){
+
+        //test 1 with existing PreviousPriceIndicator
+        prevValueIndicator = new PreviousValueIndicator(closePriceIndicator);
+        for (int i = 0; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), prevPriceIndicator.getValue(i));
+        }
+    }
+
+    @Test
+    public void shouldBePreviousValueFromIndicator(){
+
+        //test 1 with openPrice-indicator
+        prevValueIndicator = new PreviousValueIndicator(openPriceIndicator);
+        assertEquals(prevValueIndicator.getValue(0), openPriceIndicator.getValue(0));
+        for (int i = 1; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), openPriceIndicator.getValue(i-1));
+
+        }
+
+        //test 2 with minPrice-indicator
+        prevValueIndicator = new PreviousValueIndicator(minPriceIndicator);
+        assertEquals(prevValueIndicator.getValue(0), minPriceIndicator.getValue(0));
+        for (int i = 1; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), minPriceIndicator.getValue(i-1));
+
+        }
+
+        //test 3 with maxPrice-indicator
+        prevValueIndicator = new PreviousValueIndicator(maxPriceIndicator);
+        assertEquals(prevValueIndicator.getValue(0), maxPriceIndicator.getValue(0));
+        for (int i = 1; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), maxPriceIndicator.getValue(i-1));
+        }
+    }
+
+    @Test
+    public void shouldBeNthPreviousValueFromIndicator(){
+        for (int i = 0; i < this.series.getTickCount(); i++){
+            testWithN(i);
+        }
+    }
+
+    private void testWithN(int n){
+
+        // test 1 with volume-indicator
+        prevValueIndicator = new PreviousValueIndicator(volumeIndicator,n);
+        for (int i = 0; i < n; i++)
+            assertEquals(prevValueIndicator.getValue(i), volumeIndicator.getValue(0));
+
+        for (int i = n; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), volumeIndicator.getValue(i-n));
+        }
+
+        // test 2 with ema-indicator
+        prevValueIndicator = new PreviousValueIndicator(emaIndicator,n);
+        for (int i = 0; i < n; i++)
+            assertEquals(prevValueIndicator.getValue(i), emaIndicator.getValue(0));
+
+        for (int i = n; i < this.series.getTickCount(); i++){
+            assertEquals(prevValueIndicator.getValue(i), emaIndicator.getValue(i-n));
+        }
+    }
+}


### PR DESCRIPTION
This commit includes a simple indicator that returns the n-th/previous
value of a given indicator. Further a corresponding unit test class
has been added.

The 'PreviousPriceIndicator' should be declared as '@Deprecated' to avoid
redundant indicators and a missleading naming.


Enhanced #175.

Changes proposed in this pull request:
- #175


