### PR TITLE
Removed unnecessary setting of element in results cache array

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
@@ -103,8 +103,8 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
                 result = results.get(resultInnerIndex);
                 if (result == null) {
                     result = calculate(index);
+                    results.set(resultInnerIndex, result);
                 }
-                results.set(resultInnerIndex, result);
             }
         }
         return result;


### PR DESCRIPTION
Removed unnecessary setting of element in results cache array in the scenario the value has already been calculated:

https://github.com/mdeverdelhan/ta4j/blob/6b9403c68533813698ec7e47a4ff1bd72c626b1c/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java#L103-L107

The statement in line 107 should be included in the body of the if clause so that the element in `resultInnerIndex` is not overwritten by itself when `result` is not null.